### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@
 
 When participanting in large organisations on GitHub and watching all
 repositories it's getting noisy. Although the watched repositories are
-`configureable <https://github.com/watching>`_ it is time consuming to
+`configurable <https://github.com/watching>`_ it is time consuming to
 configure hundreds of repositories.
 
 The `github-watchlist` script lets you configure your watched


### PR DESCRIPTION
@jone, I've corrected a typographical error in the documentation of the [github-watchlist](https://github.com/jone/github-watchlist) project. Specifically, I've changed configureable to configurable. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.